### PR TITLE
Update 0.8.0

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,6 @@
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
-rustflags = ["-Zgcc-ld=lld"]
+# rustflags = ["-Zgcc-ld=lld"]
 
 [target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-musl-gcc"

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,6 @@
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
-# rustflags = ["-Zgcc-ld=lld"]
+rustflags = ["-Clinker=rust-lld"]
 
 [target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-musl-gcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "aio-cli"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "aio-cargo-info",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aio-cli"
 description = "Streamlined AI Terminal Interactions"
-version = "0.7.5"
+version = "0.8.0"
 edition = "2021"
 authors = ["Gabin Lefranc <gabin.lefranc@gmail.com>"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ Welcome to the README for the `aio` command line tool – your gateway to seamle
   <img src="./docs/output2.gif" style="border-radius: 10px;"/>
 </p>
 
+## 0.8 BREAKING CHANGES
+
+The default credentials path has changed from `~/.config/aio/creds.yml` to `~/.cache/aio/creds.yml`.
+
 ## Table of Contents
 
 - [aio - Streamlined AI Terminal Interactions](#aio---streamlined-ai-terminal-interactions)
+  - [0.8 BREAKING CHANGES](#08-breaking-changes)
   - [Table of Contents](#table-of-contents)
   - [Introduction](#introduction)
   - [Installation](#installation)

--- a/docs/CREDS.md
+++ b/docs/CREDS.md
@@ -13,7 +13,7 @@
 
 The credentials configuration file is used to store sensitive information, such as API keys and other secrets required for authenticating with various APIs. In the context of the `aio` project, this file stores the API keys used for interacting with AI engines like the OpenAI API. This is a separate file from `config.yaml` configuration file to easily share the configuration without compromising security.
 
-By default, `aio` will try to read the credentials configuration file from `~/.config/aio/creds.yaml`. You can also specify the path to the credentials configuration file using the `--creds-path` argument. For example: `aio --creds-path ./creds.yaml`.
+By default, `aio` will try to read the credentials configuration file from `~/.cache/aio/creds.yaml`. You can also specify the path to the credentials configuration file using the `--creds-path` argument. For example: `aio --creds-path ./creds.yaml`.
 
 ## File Structure
 

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -5,10 +5,10 @@ use clap::{Parser, ValueEnum};
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     /// Configuration file
-    #[arg(long, default_value_t = String::from("~/.config/aio/config.yml"))]
+    #[arg(long, default_value_t = format!("{1}{0}config.yml", std::path::MAIN_SEPARATOR, crate::filesystem::config_dir()))]
     pub config_path: String,
     /// Credentials file
-    #[arg(long, default_value_t = String::from("~/.config/aio/creds.yml"))]
+    #[arg(long, default_value_t = format!("{1}{0}creds.yml", std::path::MAIN_SEPARATOR, crate::filesystem::cache_dir()))]
     pub creds_path: String,
     /// Engine name
     /// 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,7 +36,7 @@ impl Config {
         let found_path = crate::filesystem::config_path(path.as_ref());
         let config = match found_path {
             Some(found_path) => {
-                Self::from_yaml_file(found_path).map_err(|e| e.to_string())?
+                <Self as DeserializeExt>::from_yaml_file(found_path).map_err(|e| e.to_string())?
             }
             None => {
                 use std::io::Write;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -17,18 +17,28 @@ pub fn home_dir() -> &'static str {
 
 pub fn config_dir() -> &'static str {
     static CONFIG: once_cell::sync::Lazy<String> = once_cell::sync::Lazy::new(|| {
-        std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+        let config_path = std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
             format!("{}{}.config", home_dir(), std::path::MAIN_SEPARATOR)
-        })
+        });
+        let config_path = format!("{}/aio", config_path);
+        if !std::path::Path::new(&config_path).exists() {
+            std::fs::create_dir(&config_path).expect("Failed to create config directory");
+        }
+        config_path
     });
     &CONFIG
 }
 
 pub fn cache_dir() -> &'static str {
     static CACHE: once_cell::sync::Lazy<String> = once_cell::sync::Lazy::new(|| {
-        std::env::var("XDG_CACHE_HOME").unwrap_or_else(|_| {
+        let cache_path = std::env::var("XDG_CACHE_HOME").unwrap_or_else(|_| {
             format!("{}{}.cache", home_dir(), std::path::MAIN_SEPARATOR)
-        })
+        });
+        let cache_path = format!("{}/aio", cache_path);
+        if !std::path::Path::new(&cache_path).exists() {
+            std::fs::create_dir(&cache_path).expect("Failed to create config directory");
+        }
+        cache_path
     });
     &CACHE
 }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,0 +1,58 @@
+use std::borrow::Cow;
+
+pub fn home_dir() -> &'static str {
+    static HOME: once_cell::sync::Lazy<String> = once_cell::sync::Lazy::new(|| {
+        #[cfg(unix)]
+        let path = std::env::var("HOME")
+            .expect("Failed to resolve home path");
+        
+        #[cfg(windows)]
+        let path = std::env::var("USERPROFILE")
+            .expect("Failed to resolve user profile path");
+        path
+    });
+
+    &HOME
+}
+
+pub fn config_dir() -> &'static str {
+    static CONFIG: once_cell::sync::Lazy<String> = once_cell::sync::Lazy::new(|| {
+        std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+            format!("{}{}.config", home_dir(), std::path::MAIN_SEPARATOR)
+        })
+    });
+    &CONFIG
+}
+
+pub fn cache_dir() -> &'static str {
+    static CACHE: once_cell::sync::Lazy<String> = once_cell::sync::Lazy::new(|| {
+        std::env::var("XDG_CACHE_HOME").unwrap_or_else(|_| {
+            format!("{}{}.cache", home_dir(), std::path::MAIN_SEPARATOR)
+        })
+    });
+    &CACHE
+}
+
+pub fn resolve_path(path: &str) -> Cow<str> {
+    if let Some(path) = path.strip_prefix("~/") {
+        Cow::Owned(format!("{}{}{}", home_dir(), std::path::MAIN_SEPARATOR, path))
+    } else {
+        Cow::Borrowed(path)
+    }
+}
+
+pub fn config_path(path: &std::path::Path) -> Option<Cow<'_, std::path::Path>> {
+    if path.exists() {
+        return Some(Cow::Borrowed(path))
+    }
+    let new_extension = match path.extension().and_then(|e| e.to_str()) {
+        Some("yml") => "yaml",
+        Some("yaml") => "yml",
+        _ => return None
+    };
+    let new_path = path.with_extension(new_extension);
+    if new_path.exists() {
+        return Some(Cow::Owned(new_path));
+    }
+    None
+}

--- a/src/generators/openai/mod.rs
+++ b/src/generators/openai/mod.rs
@@ -181,7 +181,7 @@ impl ChatResponse {
             return if let Some(error) = json.get("error") {
                 Err(serde_json::Error::custom(format!("OpenAI Error (type: {}, code: {}): {}", error["type"].as_str().unwrap_or(""), error["code"].as_str().unwrap_or(""), error["message"].as_str().unwrap_or(""))))
             } else if let Some(status) = json.get("status") {
-                Ok(ChatResponse::Status { status: status.as_str().ok_or(serde_json::Error::custom("Json found but unknown format"))?.to_string() })
+                Ok(ChatResponse::Status { status: status.as_str().ok_or(serde_json::Error::custom("OpenAI Status is not a string"))?.to_string() })
             } else {
                 Err(serde_json::Error::custom("Json found but unknown format"))
             }

--- a/src/generators/openai/mod.rs
+++ b/src/generators/openai/mod.rs
@@ -327,7 +327,7 @@ pub async fn run(creds: credentials::Credentials, config: crate::config::Config,
                         std::fs::File::options()
                             .create(true)
                             .write(true)
-                            .open(format!("{}/log.txt", crate::filesystem::cache_dir()))
+                            .open(format!("{}/openai_stream.txt", crate::filesystem::cache_dir()))
                             .expect("Failed to open log file")
                     )
                 });

--- a/src/generators/openai/mod.rs
+++ b/src/generators/openai/mod.rs
@@ -282,7 +282,12 @@ pub async fn run(creds: credentials::Credentials, config: crate::config::Config,
 
     let stream_string = stream
         .map(|input| -> Result<_, Error> {
-            Ok(SplitBytes::new(input?, b"\n\n"))
+            let input = input?;
+            // use std::io::Write;
+            // let mut f = std::fs::File::options().create(true).append(true).open(format!("{}/log.txt", crate::filesystem::cache_dir())).expect("Failed to open log file");
+            // f.write_all(&input);
+            // f.write_all(b"\n---\n");
+            Ok(SplitBytes::new(input, b"\n\n"))
         })
         .flatten_stream()
         .map(|v| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,27 @@
 pub mod arguments;
-mod runner;
-mod generators;
-mod formatters;
 mod config;
 mod credentials;
-mod serde_io;
 mod filesystem;
+mod formatters;
+mod generators;
+mod runner;
+mod serde_io;
 
+mod openai {}
+
+use arguments as args;
 use clap::Parser;
+use formatters::Formatter;
 use serde_io::DeserializeExt;
 use tokio_stream::StreamExt;
-use arguments as args;
-use formatters::Formatter;
 
 macro_rules! raise_str {
     ($expr:expr) => {
         raise_str!($expr, "{}")
     };
-    ($expr:expr, $text:literal) => {
-        { $expr.map_err(|e| format!($text, e))? }
-    };
+    ($expr:expr, $text:literal) => {{
+        $expr.map_err(|e| format!($text, e))?
+    }};
 }
 
 #[tokio::main]
@@ -30,15 +32,26 @@ async fn main() -> Result<(), String> {
             use std::io::Read;
             let mut str_input = std::string::String::new();
             let mut stdin = std::io::stdin();
-            stdin.read_to_string(&mut str_input).map_err(|e| format!("Failed to read input from stdin: {}", e))?;
-            
+            stdin
+                .read_to_string(&mut str_input)
+                .map_err(|e| format!("Failed to read input from stdin: {}", e))?;
+
             args.input = Some(str_input.trim().to_string());
         }
         args::ProcessedArgs::from(args)
     };
-    let config = config::Config::from_yaml_file(filesystem::resolve_path(&args.config_path).as_ref()).map_err(|e| format!("An error occured while loading or creating configuration file: {}", e))?;
+    let config =
+        config::Config::from_yaml_file(filesystem::resolve_path(&args.config_path).as_ref())
+            .map_err(|e| {
+                format!(
+                    "An error occured while loading or creating configuration file: {}",
+                    e
+                )
+            })?;
     let creds = raise_str!(
-        credentials::Credentials::from_yaml_file(filesystem::resolve_path(&args.creds_path).as_ref()),
+        credentials::Credentials::from_yaml_file(
+            filesystem::resolve_path(&args.creds_path).as_ref()
+        ),
         "Failed to parse credentials file: {}"
     );
 
@@ -48,23 +61,28 @@ async fn main() -> Result<(), String> {
     };
     let mut runner = runner::Runner::new(args.run);
 
-    let (engine, _prompt) = args.engine
+    let (engine, _prompt) = args
+        .engine
         .find(':')
-        .map(|i| (&args.engine[..i], Some(&args.engine[i+1..])))
+        .map(|i| (&args.engine[..i], Some(&args.engine[i + 1..])))
         .unwrap_or((args.engine.as_str(), None));
 
     let mut stream = match engine {
         "openai" => generators::openai::run(creds.openai, config, args).await,
         "from-file" => generators::debug::run(config, args).await,
         _ => panic!("Unknown engine: {}", engine),
-    }.map_err(|e| format!("Failed to request OpenAI API: {}", e))?;
+    }
+    .map_err(|e| format!("Failed to request OpenAI API: {}", e))?;
 
     loop {
         match stream.next().await {
             Some(Ok(token)) => {
                 raise_str!(formatter.push(&token), "Failed to parse markdown: {}");
-                raise_str!(runner.push(&token), "Failed push text in the runner system: {}");
-            },
+                raise_str!(
+                    runner.push(&token),
+                    "Failed push text in the runner system: {}"
+                );
+            }
             Some(Err(e)) => Err(e.to_string())?,
             None => break,
         }
@@ -73,3 +91,4 @@ async fn main() -> Result<(), String> {
     raise_str!(runner.end_of_document(), "Failed to run code: {}");
     Ok(())
 }
+

--- a/src/runner/program/cache.rs
+++ b/src/runner/program/cache.rs
@@ -2,6 +2,8 @@ use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use thiserror::Error;
 use serde::{Deserialize, Serialize};
 
+use crate::filesystem;
+
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Cache {
     programs: std::collections::HashMap<String, String>,
@@ -59,7 +61,7 @@ impl Cache {
         }
     }
     fn cache_path() -> std::path::PathBuf {
-        std::path::Path::new(crate::home_dir()).join(".cache").join("aio.yaml")
+        std::path::Path::new(filesystem::cache_dir()).join("aio.yaml")
     }
 }
 pub fn get_program(program: &str) -> Option<String> {


### PR DESCRIPTION
## BREAKING CHANGE

* Credentials files move from `~/.config/aio/creds.yml` to `~/.cache/aio/creds.yml`

## Improvements

* In debug mode, add raw OpenAI API stream log. The fils is located in `~/.cache/aio/openai_stream.txt`

## Fixes

* Program crash when OpenAI stream is not complete in a stream cycle.